### PR TITLE
support context.Context on request

### DIFF
--- a/url2png_test.go
+++ b/url2png_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,6 +33,21 @@ func TestScreenshot(t *testing.T) {
 	n, err := ioutil.ReadAll(r)
 	a.NoError(err)
 	a.NotEqual(0, n)
+}
+
+func TestCancel(t *testing.T) {
+	t.Parallel()
+
+	a := assert.New(t)
+
+	c := newClient()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r, err := c.ScreenshotWithContext(ctx, "http://www.fknsrs.biz/", nil)
+	a.Error(err)
+	a.Equal("context canceled", err.Error())
+	a.Nil(r)
 }
 
 func TestBadURL(t *testing.T) {


### PR DESCRIPTION
#### What's this PR do?

Append `ScreenshotWithContext` method to `url2png.Client` to support context.Context on HTTP request.

#### Where should the reviewer start?

`url2png.go`

#### How should this be manually tested?

`TEST_KEY=`_TEST_KEY_` TEST_SECRET=`_TEST_SECRET_` go test --race ./...`
